### PR TITLE
Update Project_3_Control_Servo_via_PWM.py

### DIFF
--- a/demo_code/Project_3_Control_Servo_via_PWM.py
+++ b/demo_code/Project_3_Control_Servo_via_PWM.py
@@ -2,7 +2,7 @@ from machine import Pin, PWM
 from time import sleep
 from math import floor
 
-pwm = PWM(Pin(15))
+pwm = PWM(Pin(0))
 pwm.freq(50)
 duty = 0
 pwm.duty_u16(duty)


### PR DESCRIPTION
Fritzing diagram for example 3 shows the servo signal line connected to GP0, but this code example shows it connected to GP15.  The code needs to match the Fritzing diagram.